### PR TITLE
Language tab edge cases

### DIFF
--- a/src/Language.js
+++ b/src/Language.js
@@ -9,7 +9,7 @@ const LanguageFwd = React.forwardRef(Language)
 
 export { LanguageFwd as Language }
 
-function Language({ value }, ref) {
+function Language({ value = '' }, ref) {
   if (!value) return (
     <Card padding={3} tone='critical' shadow={1} radius={2}>
       <input type='hidden' {...{ value, ref }} />

--- a/src/Language.js
+++ b/src/Language.js
@@ -7,7 +7,9 @@ import pluginConfig from 'config:@kaliber/sanity-plugin-multi-language'
 export function Language({ value }) {
   if (!value) {
     return (
-      <Card padding={3} tone='critical' shadow={1} radius={2}><Text>This is not right, this document doesn't have a language associated with it.</Text></Card>
+      <Card padding={3} tone='critical' shadow={1} radius={2}>
+        <Text>This is not right, this document doesn't have a language associated with it.</Text>
+      </Card>
     )
   }
 

--- a/src/Translations.js
+++ b/src/Translations.js
@@ -56,7 +56,7 @@ function Translations({ document: { displayed: document, draft, published } }) {
   const paneRouter = usePaneRouter()
   const router = useRouter()
 
-  useOnChildDocumentDeletedDeleteHack(() => {
+  useOnChildDocumentDeletedHack(() => {
     closeChildPanes()
     queryClient.invalidateQueries(['translations'])
   })
@@ -310,7 +310,7 @@ function PreviewBase({ document, flag = undefined, muted }) {
   )
 }
 
-function useOnChildDocumentDeletedDeleteHack(onDelete) {
+function useOnChildDocumentDeletedHack(onDelete) {
   const paneRouter = usePaneRouter()
   const callbackRef = React.useRef(null)
   callbackRef.current = onDelete

--- a/src/Translations.js
+++ b/src/Translations.js
@@ -53,6 +53,11 @@ function Translations({ document: { displayed: document, draft, published } }) {
   const paneRouter = usePaneRouter()
   const router = useRouter()
 
+  useOnChildDocumentDeletedDeleteHack(() => {
+    closeChildPanes()
+    queryClient.invalidateQueries(['translations'])
+  })
+
   // TODO: Show toast on error
 
   const { mutate: addFreshTranslation } = useMutation({
@@ -151,6 +156,10 @@ function Translations({ document: { displayed: document, draft, published } }) {
   function handleQueryError(e) {
     reportError(e)
     alert('Something went wrong, please try again')
+  }
+
+  function closeChildPanes() {
+    router.navigate({ panes: paneRouter.routerPanesState.slice(0, paneRouter.groupIndex + 1) })
   }
 }
 
@@ -295,6 +304,29 @@ function PreviewBase({ document, flag = undefined, muted }) {
         </Box>
       </Flex>
     </Card>
+  )
+}
+
+function useOnChildDocumentDeletedDeleteHack(onDelete) {
+  const paneRouter = usePaneRouter()
+  const callbackRef = React.useRef(null)
+  callbackRef.current = onDelete
+
+  const [lastPane] = paneRouter.routerPanesState[paneRouter.groupIndex + 1] ?? [{ id: 'no-doc', params: {} }]
+  const editState = useEditState(lastPane.id.replace(/^drafts\./, ''), lastPane.params.type)
+  const previousDocRef = React.useRef(editState.draft ?? editState.published)
+
+  React.useEffect(
+    () => { 
+      const doc = editState.draft ?? editState.published
+
+      if (previousDocRef.current && !doc) {
+        callbackRef.current()
+      }
+
+      previousDocRef.current = doc
+    },
+    [editState]
   )
 }
 

--- a/src/multi-language.js
+++ b/src/multi-language.js
@@ -2,7 +2,6 @@ import * as uuid from 'uuid'
 import pluginConfig from 'config:@kaliber/sanity-plugin-multi-language'
 import { Language } from './Language'
 import client from 'part:@sanity/base/client'
-
 export { Translations, typeHasLanguage } from './Translations'
 
 const sanityClient = client.withConfig({ apiVersion: '2022-03-16' })
@@ -55,18 +54,18 @@ function addFieldsToSchema(schema, { fieldset }) {
 
     return {
       ...result,
-      language: getParentRefLanguageHack() ?? pluginConfig.defaultLanguage,
+      language: (await getParentRefLanguageHack()) ?? pluginConfig.defaultLanguage,
       translationId: uuid.v4()
     }
   }
 }
 
-function getParentRefLanguageHack() {
+async function getParentRefLanguageHack() {
   const segments = decodeURIComponent(window.location.pathname).split(';')
   const currentSegment = segments.slice(-1).shift()
   const [parentId] = segments.slice(-2).shift()?.split(',')
 
-  return currentSegment?.includes('parentRefPath')
+  return (currentSegment?.includes('parentRefPath') && parentId)
     ? await sanityClient.fetch(`*[_id in [$parentId, 'drafts.' + $parentId]][0].language`, { parentId })
     : null
 }


### PR DESCRIPTION
Bij het testen kwam ik een tweetal edge-cases tegen waar eigenlijk niet op een goede manier omheen te werken was. Stel je default language is NL.

1. Als je een vertaling aanmaakt in het EN opent deze in een nieuw pane. Als je deze vervolgens direct verwijdert, sluit Sanity het pane niet, maar krijg je een leeg document in dat pane. Deze is (afhankelijk van de timing) helemaal leeg, of bevat nieuw gegenereerde initial values (language NL en een uniek, nieuw translationId). 
2. Als je in een EN document een reference in place aanmaakt (nieuwe functionaliteit), krijgt deze als initial value de language NL mee. Vanuit de initialValue heb je geen context, dus weet je niet of (en zo ja, in welke taal) dit document een parent heeft.

Ik heb die nu opgelost met 2 hacks. Van punt 2 verwacht ik dat ze hier zelf ook met een fix zullen moeten komen.

Hack 1: ik houd welk document in een child pane nieuw is aangemaakt. Als dit document verandert in een blanco (omdat het is verwijderd), sluit ik het child pane.

Hack 2: ik kijk naar de url om te bepalen of het document dat wordt aangemaakt een child ref is van een eventueel parent document. Als dat zo is, neem ik de taal van dat document over.