### PR TITLE
DIGP-335 - Use random uuid

### DIFF
--- a/src/Translations.js
+++ b/src/Translations.js
@@ -415,7 +415,7 @@ async function createDuplicateTranslation({ original, language }) {
     sanityClient.patch(_id).setIfMissing({ translationId }).commit(), // TODO: kan dit echt gebeuren?
     sanityClient.create({
       ...(await pointReferencesToTranslatedDocument(document, language)),
-      _id: 'drafts.' + uuid.uuid.v4(),
+      _id: 'drafts.' + uuid.v4(),
       translationId,
       language
     })

--- a/src/Translations.js
+++ b/src/Translations.js
@@ -356,7 +356,7 @@ async function getTranslations(context) {
 }
 
 async function addFreshTranslation({ original, language }) {
-  const duplicateId = 'drafts.' + uuid.v5([language, original._id].join('.'), uuid.v5.URL)
+  const duplicateId = 'drafts.' + uuid.v4()
 
   const result = await sanityClient.create({
     _type: original._type, _id: duplicateId, translationId: original.translationId, language
@@ -415,7 +415,7 @@ async function createDuplicateTranslation({ original, language }) {
     sanityClient.patch(_id).setIfMissing({ translationId }).commit(), // TODO: kan dit echt gebeuren?
     sanityClient.create({
       ...(await pointReferencesToTranslatedDocument(document, language)),
-      _id: 'drafts.' + uuid.v5([language, original._id].join('.'), uuid.v5.URL),
+      _id: 'drafts.' + uuid.uuid.v4(),
       translationId,
       language
     })
@@ -515,4 +515,3 @@ function removeExcludedReferences(data, exclude) {
     ? data.map(x => removeExcludedReferences(x, exclude)).filter(Boolean)
     : mapValues(data, x => removeExcludedReferences(x, exclude))
 }
-


### PR DESCRIPTION
https://kaliber.atlassian.net/browse/DIGP-335
Bij Digital Power ging er iets fout met het creeeren van de vertaling. 
Ik kan niet achterhalen wat er fout is gegaan, maar het resultaat is dat er een document wordt aangemaakt zonder translationId is gemaakt.
De _id wordt echter deterministisch gegenereerd, dit zorgt ervoor dat je wanneer je de translation opnieuw probeert te maken, de volgende foutmelding krijgt: `'Document by ID "drafts.742a4bcd-a691-5180-aa69-25d8bc5f4db9" already exists'`
De fix die ik hier heb voorgesteld is om een uuid.v4() te gebruiken, aangezien ik niet kan bedenken waarom we de uuid deterministisch willen genereren, de koppeling met het originele document zou namelijk moeten gebeuren met het translationdId, niet met het _id, en geeft dit dus een onnodige beperking/complexiteit. Maar misschien zie ik iets over het hoofd.