### PR TITLE
Remove toLowerCase() for correct duplicate button label

### DIFF
--- a/src/components/Translations.js
+++ b/src/components/Translations.js
@@ -284,7 +284,7 @@ function TranslateActions({ onClickDuplicate, onClickFresh, language, languages 
   return (
     <Flex gap={3} align='center'>
       <Button onClick={onClickFresh} icon={ComposeIcon} tone='primary' mode='ghost' text='Create empty translation' style={{ width: '100%'}} />
-      <Button onClick={onClickDuplicate} icon={DocumentsIcon} tone='primary' text={`Duplicate in ${languages[language].title.toLowerCase()}`} style={{ width: '100%'}} />
+      <Button onClick={onClickDuplicate} icon={DocumentsIcon} tone='primary' text={`Duplicate in ${languages[language].title}`} style={{ width: '100%'}} />
     </Flex>
   )
 }


### PR DESCRIPTION
Vanuit UX kreeg ik te horen dat de button label niet op de juiste manier is. De taal zou met een hoofdletter moeten zijn. 
`Duplicate in dutch` > `Duplicate in Dutch`.