### PR TITLE
Add optional title overrides for language and translation fields

### DIFF
--- a/src/addFields.js
+++ b/src/addFields.js
@@ -16,7 +16,7 @@ export function addFields(config) {
       ...type,
       fields: [
         {
-          title: 'Taal',
+          title: config.languageFieldTitle ?? 'Taal',
           name: 'language',
           type: 'string',
           readOnly: true,
@@ -34,7 +34,7 @@ export function addFields(config) {
           },
         },
         {
-          title: 'Vertalings ID',
+          title: config.translationIdFieldTitle ?? 'Vertalings ID',
           name: 'translationId',
           type: 'string',
           of: [{ type: 'string' }],

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 export type Config = {
   reportError(error: any): void,
+  languageFieldTitle?: string,
+  translationIdFieldTitle?: string,
   multiLanguage: {
     languages: {
       [language: string]: {


### PR DESCRIPTION
Previously, the "Taal" and "Vertalings ID" titles were hardcoded. This PR updates the plugin to accept optional `languageFieldTitle` and `translationIdFieldTitle` properties in the config object, falling back to the original Dutch titles when not provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options to customize the titles of language and translation ID fields. Default titles are preserved when custom configuration values are not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->